### PR TITLE
前の録音データがリングバッファに残ってしまっている問題を解決した。

### DIFF
--- a/src/audio/audio_recorder.cpp
+++ b/src/audio/audio_recorder.cpp
@@ -37,6 +37,14 @@ AudioRecorder::~AudioRecorder() {
     }
 }
 
+void AudioRecorder::resetRingBuffer() {
+    if (xSemaphoreTake(ringBufferMutex, portMAX_DELAY) == pdTRUE) {
+        writeIndex = 0;
+        readIndex  = 0;
+        xSemaphoreGive(ringBufferMutex);
+    }
+}
+
 void AudioRecorder::initialize() {
     this->tempBuffer = (uint8_t*)ps_malloc(BUFFER_SIZE);
     audioRingBuffer = (uint8_t*)ps_malloc(BUFFER_SIZE);
@@ -88,6 +96,7 @@ void AudioRecorder::startRecording(AppState &state) {
     if (recording || recordingTaskHandle != nullptr) return;
     String recordedAt = getFormattedTime();
     String response;
+    resetRingBuffer();
     switch (state.selectedRecordType) {
     case MEAL:
         //食事記録作成

--- a/src/audio/audio_recorder.h
+++ b/src/audio/audio_recorder.h
@@ -14,6 +14,7 @@ public:
     AudioRecorder();
     ~AudioRecorder();
 
+    void resetRingBuffer();  
     void startRecording(AppState &state);
     void stopRecording();
     bool isRecording() const{return recording;};

--- a/src/audio/audio_recorder.h
+++ b/src/audio/audio_recorder.h
@@ -5,7 +5,7 @@
 #include <driver/i2s.h>
 #include <SD.h>
 
-#define BUFFER_SIZE (16000 * 2 * 20)
+#define BUFFER_SIZE (16000 * 2 * 40)
 
 struct AppState; // 前方宣言
 

--- a/src/services/transcription/whisper_client.cpp
+++ b/src/services/transcription/whisper_client.cpp
@@ -11,6 +11,7 @@
 #include "../../screens/screen_display_extract.h"
 #include "../api/records.h"
 #include <WiFiClientSecure.h>
+#include "../../system/sd_handler.h"
 
 //extern AudioRecorder recorder;
 const char* API_KEY = OPENAI_API_KEY;
@@ -218,12 +219,12 @@ void transcribeAudio() {
           Serial.println("No new data in ring buffer");
         }
         Serial.println("open SD");
-        SD.remove("/recording.wav");
-        File recordingFile = SD.open("/recording.wav", FILE_WRITE);
-        writeWavHeader(recordingFile, 16000, 16, 1);
+        initializeRecordFile();
+        File recordingFile = SD.open("/recording.wav", FILE_APPEND);
         recordingFile.write(recorder.gettempBuffer(), available);
+        recordingFile.close();
+        recordingFile = SD.open("/recording.wav", "r+");
         updateWavHeader(recordingFile);
-        recordingFile.flush();
         recordingFile.close();
     }
     Serial.println("complete reccording.wav");

--- a/src/system/sd_handler.cpp
+++ b/src/system/sd_handler.cpp
@@ -1,9 +1,17 @@
 #include "sd_handler.h"
 #include <Arduino.h>
 #include <SD.h>
+#include "../services/transcription/whisper_client.h"
 
 bool initializeSD() {
     return SD.begin();
+}
+
+void initializeRecordFile(){//いずれ汎用化します
+    SD.remove("/recording.wav");
+    File recordingFile = SD.open("/recording.wav", FILE_WRITE);
+    writeWavHeader(recordingFile, 16000, 16, 1);
+    recordingFile.close();
 }
 
 void readFileFromSD(const char* filename) {

--- a/src/system/sd_handler.h
+++ b/src/system/sd_handler.h
@@ -3,5 +3,6 @@
 
 bool initializeSD();
 void readFileFromSD(const char* filename);
+void initializeRecordFile();
 
 #endif

--- a/src/system/wifi_manager.cpp
+++ b/src/system/wifi_manager.cpp
@@ -11,6 +11,7 @@ void connectToWiFi(String ssid, String password) {
     M5.Lcd.drawString("ネットワーク通信中...", M5.Lcd.width() / 2, M5.Lcd.height() * 3 / 4);
     WiFi.begin(ssid, password);
     while (WiFi.status() != WL_CONNECTED) {
+        Serial.println(WiFi.status());
         delay(500);
     }
     M5.Lcd.fillRect(0, 140, 340, 120, WHITE);


### PR DESCRIPTION
## 概要


## 関連タスク
Close #159 (required)

## やったこと
AudioクラスにinitializeBufferメソッドを追加。インデックスを0に戻すことで初期化
スタートレコーディングで呼び出す。

## やらないこと


## レビュー事項
-

## 補足 参考情報


